### PR TITLE
feat(core): Implement quota and balance calculation logic (CotaService)

### DIFF
--- a/app/Models/Consumidor.php
+++ b/app/Models/Consumidor.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -11,9 +12,21 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  *
  * Esta entidade armazena apenas informações mínimas (codpes e nome),
  * pois os dados completos são consultados em tempo real via Replicado.
+ *
+ * @use HasFactory<\Database\Factories\ConsumidorFactory>
  */
 class Consumidor extends Model
 {
+    /** @use HasFactory<\Database\Factories\ConsumidorFactory> */
+    use HasFactory;
+
+    /**
+     * O nome da tabela associada ao modelo.
+     *
+     * @var string
+     */
+    protected $table = 'consumidores';
+
     /**
      * A chave primária customizada para esta tabela.
      *

--- a/app/Models/CotaEspecial.php
+++ b/app/Models/CotaEspecial.php
@@ -14,6 +14,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class CotaEspecial extends Model
 {
     /**
+     * O nome da tabela associada ao modelo.
+     *
+     * @var string
+     */
+    protected $table = 'cota_especiais';
+
+    /**
      * Os atributos que podem ser atribuídos em massa.
      *
      * @var list<string>

--- a/app/Models/CotaRegular.php
+++ b/app/Models/CotaRegular.php
@@ -13,6 +13,13 @@ use Illuminate\Database\Eloquent\Model;
 class CotaRegular extends Model
 {
     /**
+     * O nome da tabela associada ao modelo.
+     *
+     * @var string
+     */
+    protected $table = 'cota_regulares';
+
+    /**
      * Os atributos que podem ser atribuídos em massa.
      *
      * @var list<string>

--- a/app/Models/Produto.php
+++ b/app/Models/Produto.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -9,9 +10,14 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * Produto - Representa os produtos disponíveis para consumo.
  *
  * Cada produto tem um nome único e um valor em unidades de cota.
+ *
+ * @use HasFactory<\Database\Factories\ProdutoFactory>
  */
 class Produto extends Model
 {
+    /** @use HasFactory<\Database\Factories\ProdutoFactory> */
+    use HasFactory;
+
     /**
      * Os atributos que podem ser atribuídos em massa.
      *

--- a/app/Services/CotaService.php
+++ b/app/Services/CotaService.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Consumidor;
+use App\Models\CotaRegular;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Serviço responsável pelo cálculo de cota e saldo de consumidores.
+ *
+ * Implementa a lógica central do sistema para determinar quanto
+ * crédito um consumidor possui disponível no mês corrente.
+ */
+class CotaService
+{
+    /**
+     * Código da unidade IME-USP.
+     */
+    private const CODUND_IME = 8;
+
+    /**
+     * Cria uma nova instância do serviço.
+     *
+     * @param  ReplicadoService  $replicadoService  Serviço para consultar dados do Replicado.
+     */
+    public function __construct(
+        private ReplicadoService $replicadoService
+    ) {}
+
+    /**
+     * Calcula o saldo disponível para um consumidor no mês atual.
+     *
+     * Este método implementa a lógica central do sistema de cotas:
+     * 1. Determina a cota mensal (especial > regular > zero)
+     * 2. Calcula o gasto acumulado no mês atual
+     * 3. Retorna o saldo (cota - gasto)
+     *
+     * @param  Consumidor  $consumidor  O consumidor a ser verificado.
+     * @return array{cota: int, gasto: int, saldo: int} Array associativo com:
+     *                                                  - cota: Valor da cota mensal do consumidor
+     *                                                  - gasto: Total gasto no mês atual
+     *                                                  - saldo: Saldo disponível (pode ser negativo)
+     *
+     * @throws \App\Exceptions\ReplicadoServiceException Se houver erro ao consultar o Replicado.
+     */
+    public function calcularSaldoParaConsumidor(Consumidor $consumidor): array
+    {
+        $cota = $this->obterCotaMensal($consumidor);
+        $gasto = $this->calcularGastoMensal($consumidor);
+        $saldo = $cota - $gasto;
+
+        Log::info("CotaService: Calculated saldo for codpes {$consumidor->codpes}.", [
+            'codpes' => $consumidor->codpes,
+            'cota' => $cota,
+            'gasto' => $gasto,
+            'saldo' => $saldo,
+        ]);
+
+        return [
+            'cota' => $cota,
+            'gasto' => $gasto,
+            'saldo' => $saldo,
+        ];
+    }
+
+    /**
+     * Determina a cota mensal de um consumidor.
+     *
+     * Segue a ordem de prioridade:
+     * 1. Cota Especial (se existir)
+     * 2. Maior Cota Regular entre os vínculos ativos do IME
+     * 3. Zero (se não houver cotas aplicáveis)
+     *
+     * @param  Consumidor  $consumidor  O consumidor.
+     * @return int Valor da cota mensal.
+     *
+     * @throws \App\Exceptions\ReplicadoServiceException Se houver erro ao consultar vínculos.
+     */
+    private function obterCotaMensal(Consumidor $consumidor): int
+    {
+        // 1. Verifica se existe Cota Especial
+        $cotaEspecial = $consumidor->cotaEspecial;
+        if ($cotaEspecial !== null) {
+            $valor = $cotaEspecial->valor;
+            Log::info("CotaService: Using special cota for codpes {$consumidor->codpes}: {$valor}");
+
+            return $valor;
+        }
+
+        // 2. Busca vínculos ativos no IME
+        $vinculos = $this->replicadoService->obterVinculosAtivos(
+            $consumidor->codpes,
+            self::CODUND_IME
+        );
+
+        if (empty($vinculos)) {
+            Log::info("CotaService: No active vinculos found for codpes {$consumidor->codpes} in IME.");
+
+            return 0;
+        }
+
+        // 3. Busca a maior cota regular entre os vínculos
+        /** @var int|null $maiorCota */
+        $maiorCota = CotaRegular::whereIn('vinculo', $vinculos)
+            ->max('valor');
+
+        if ($maiorCota === null) {
+            Log::info("CotaService: No matching regular cota found for vinculos of codpes {$consumidor->codpes}.", [
+                'vinculos' => $vinculos,
+            ]);
+
+            return 0;
+        }
+
+        Log::info("CotaService: Using regular cota for codpes {$consumidor->codpes}: ".(string) $maiorCota, [
+            'vinculos' => $vinculos,
+        ]);
+
+        return $maiorCota;
+    }
+
+    /**
+     * Calcula o total gasto pelo consumidor no mês atual.
+     *
+     * Soma o valor de todos os pedidos realizados no mês e ano correntes.
+     * Valor do pedido = Σ (quantidade × produto.valor) para todos os itens.
+     *
+     * @param  Consumidor  $consumidor  O consumidor.
+     * @return int Total gasto no mês atual.
+     */
+    private function calcularGastoMensal(Consumidor $consumidor): int
+    {
+        $mesAtual = now()->month;
+        $anoAtual = now()->year;
+
+        $gasto = $consumidor->pedidos()
+            ->whereYear('created_at', $anoAtual)
+            ->whereMonth('created_at', $mesAtual)
+            ->with('itens.produto')
+            ->get()
+            ->sum(function ($pedido) {
+                return $pedido->itens->sum(function ($item) {
+                    $produto = $item->produto;
+                    if ($produto === null) {
+                        return 0;
+                    }
+
+                    return $item->quantidade * $produto->valor;
+                });
+            });
+
+        return (int) $gasto;
+    }
+}

--- a/database/factories/ConsumidorFactory.php
+++ b/database/factories/ConsumidorFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Consumidor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Consumidor>
+ */
+class ConsumidorFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = Consumidor::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'codpes' => fake()->unique()->numberBetween(100000, 999999),
+            'nome' => fake()->name(),
+        ];
+    }
+}

--- a/database/factories/ProdutoFactory.php
+++ b/database/factories/ProdutoFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Produto;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Produto>
+ */
+class ProdutoFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = Produto::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'nome' => fake()->word().' '.fake()->randomElement(['Café', 'Chá', 'Suco', 'Biscoito']),
+            'valor' => fake()->numberBetween(5, 20),
+        ];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,7 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>

--- a/tests/Fakes/FakeReplicadoService.php
+++ b/tests/Fakes/FakeReplicadoService.php
@@ -22,6 +22,16 @@ class FakeReplicadoService extends ReplicadoService
     public bool $shouldThrowException = false;
 
     /**
+     * Storage for fake pessoa data.
+     */
+    private array $pessoas = [];
+
+    /**
+     * Storage for fake vinculos data.
+     */
+    private array $vinculos = [];
+
+    /**
      * Simulates the validation logic.
      *
      *
@@ -63,5 +73,71 @@ class FakeReplicadoService extends ReplicadoService
         $this->shouldThrowException = true;
 
         return $this;
+    }
+
+    /**
+     * Sets fake pessoa data for a specific codpes.
+     *
+     * @param  array  $data  Array with keys: 'nompes', 'emailusp'
+     * @return $this
+     */
+    public function setPessoa(int $codpes, array $data): self
+    {
+        $this->pessoas[$codpes] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Sets fake vinculos data for a specific codpes and unit.
+     *
+     * @param  array  $vinculos  Array of vinculos siglas (e.g., ['SERVIDOR', 'ALUNOPOS'])
+     * @return $this
+     */
+    public function setVinculos(int $codpes, int $codund, array $vinculos): self
+    {
+        $this->vinculos["{$codpes}_{$codund}"] = $vinculos;
+
+        return $this;
+    }
+
+    /**
+     * Simulates buscarPessoa method.
+     *
+     *
+     * @throws \App\Exceptions\ReplicadoServiceException
+     */
+    public function buscarPessoa(int $codpes): ?array
+    {
+        if ($this->shouldThrowException) {
+            throw new ReplicadoServiceException('Simulated Replicado service communication error.');
+        }
+
+        if (! isset($this->pessoas[$codpes])) {
+            return null;
+        }
+
+        return [
+            'codpes' => $codpes,
+            'nompes' => $this->pessoas[$codpes]['nompes'] ?? 'Test Person',
+            'emailusp' => $this->pessoas[$codpes]['emailusp'] ?? 'test@usp.br',
+        ];
+    }
+
+    /**
+     * Simulates obterVinculosAtivos method.
+     *
+     *
+     * @throws \App\Exceptions\ReplicadoServiceException
+     */
+    public function obterVinculosAtivos(int $codpes, int $codund): array
+    {
+        if ($this->shouldThrowException) {
+            throw new ReplicadoServiceException('Simulated Replicado service communication error.');
+        }
+
+        $key = "{$codpes}_{$codund}";
+
+        return $this->vinculos[$key] ?? [];
     }
 }

--- a/tests/Unit/Services/CotaServiceTest.php
+++ b/tests/Unit/Services/CotaServiceTest.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Consumidor;
+use App\Models\CotaEspecial;
+use App\Models\CotaRegular;
+use App\Models\ItemPedido;
+use App\Models\Pedido;
+use App\Models\Produto;
+use App\Services\CotaService;
+use Tests\Fakes\FakeReplicadoService;
+use Tests\TestCase;
+
+class CotaServiceTest extends TestCase
+{
+    private CotaService $cotaService;
+
+    private FakeReplicadoService $fakeReplicado;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Configura o Fake Replicado Service
+        $this->fakeReplicado = new FakeReplicadoService;
+        $this->cotaService = new CotaService($this->fakeReplicado);
+    }
+
+    /**
+     * Testa o cálculo de saldo para consumidor com cota especial.
+     */
+    public function test_calcula_saldo_com_cota_especial(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 123456,
+            'nome' => 'João Silva',
+        ]);
+
+        CotaEspecial::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'valor' => 50,
+        ]);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert
+        $this->assertEquals(50, $resultado['cota']);
+        $this->assertEquals(0, $resultado['gasto']);
+        $this->assertEquals(50, $resultado['saldo']);
+    }
+
+    /**
+     * Testa o cálculo de saldo para consumidor com cota regular (único vínculo).
+     */
+    public function test_calcula_saldo_com_cota_regular_unico_vinculo(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 654321,
+            'nome' => 'Maria Santos',
+        ]);
+
+        CotaRegular::create([
+            'vinculo' => 'SERVIDOR',
+            'valor' => 30,
+        ]);
+
+        $this->fakeReplicado->setVinculos(654321, 8, ['SERVIDOR']);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert
+        $this->assertEquals(30, $resultado['cota']);
+        $this->assertEquals(0, $resultado['gasto']);
+        $this->assertEquals(30, $resultado['saldo']);
+    }
+
+    /**
+     * Testa o cálculo de saldo para consumidor com múltiplos vínculos (deve usar a maior cota).
+     */
+    public function test_calcula_saldo_com_multiplos_vinculos_usa_maior_cota(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 111222,
+            'nome' => 'Pedro Oliveira',
+        ]);
+
+        CotaRegular::create([
+            'vinculo' => 'SERVIDOR',
+            'valor' => 30,
+        ]);
+
+        CotaRegular::create([
+            'vinculo' => 'ALUNOPOS',
+            'valor' => 20,
+        ]);
+
+        CotaRegular::create([
+            'vinculo' => 'DOCENTE',
+            'valor' => 40,
+        ]);
+
+        $this->fakeReplicado->setVinculos(111222, 8, ['SERVIDOR', 'ALUNOPOS', 'DOCENTE']);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert - Deve usar a maior cota (DOCENTE = 40)
+        $this->assertEquals(40, $resultado['cota']);
+        $this->assertEquals(0, $resultado['gasto']);
+        $this->assertEquals(40, $resultado['saldo']);
+    }
+
+    /**
+     * Testa o cálculo de saldo para consumidor sem cota (nenhum vínculo).
+     */
+    public function test_calcula_saldo_sem_cota_nenhum_vinculo(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 999888,
+            'nome' => 'Ana Costa',
+        ]);
+
+        // Não configura vínculos no fake (retornará array vazio)
+        $this->fakeReplicado->setVinculos(999888, 8, []);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert
+        $this->assertEquals(0, $resultado['cota']);
+        $this->assertEquals(0, $resultado['gasto']);
+        $this->assertEquals(0, $resultado['saldo']);
+    }
+
+    /**
+     * Testa o cálculo de saldo para consumidor com vínculos, mas sem cota regular cadastrada.
+     */
+    public function test_calcula_saldo_sem_cota_regular_cadastrada(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 777666,
+            'nome' => 'Carlos Ferreira',
+        ]);
+
+        // Configura vínculo, mas não cadastra cota regular correspondente
+        $this->fakeReplicado->setVinculos(777666, 8, ['ESTAGIARIO']);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert
+        $this->assertEquals(0, $resultado['cota']);
+        $this->assertEquals(0, $resultado['gasto']);
+        $this->assertEquals(0, $resultado['saldo']);
+    }
+
+    /**
+     * Testa o cálculo de saldo com gastos no mês atual.
+     */
+    public function test_calcula_saldo_com_gastos_no_mes_atual(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 555444,
+            'nome' => 'Fernanda Lima',
+        ]);
+
+        CotaEspecial::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'valor' => 50,
+        ]);
+
+        $produto1 = Produto::factory()->create(['valor' => 5]);
+        $produto2 = Produto::factory()->create(['valor' => 10]);
+
+        $pedido = Pedido::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'estado' => 'REALIZADO',
+        ]);
+
+        ItemPedido::create([
+            'pedido_id' => $pedido->id,
+            'produto_id' => $produto1->id,
+            'quantidade' => 2, // 2 x 5 = 10
+        ]);
+
+        ItemPedido::create([
+            'pedido_id' => $pedido->id,
+            'produto_id' => $produto2->id,
+            'quantidade' => 1, // 1 x 10 = 10
+        ]);
+
+        // Total gasto = 10 + 10 = 20
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert
+        $this->assertEquals(50, $resultado['cota']);
+        $this->assertEquals(20, $resultado['gasto']);
+        $this->assertEquals(30, $resultado['saldo']);
+    }
+
+    /**
+     * Testa o cálculo de saldo negativo quando gasto excede a cota.
+     */
+    public function test_calcula_saldo_negativo_quando_gasto_excede_cota(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 333222,
+            'nome' => 'Roberto Alves',
+        ]);
+
+        CotaEspecial::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'valor' => 20,
+        ]);
+
+        $produto = Produto::factory()->create(['valor' => 15]);
+
+        $pedido = Pedido::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'estado' => 'REALIZADO',
+        ]);
+
+        ItemPedido::create([
+            'pedido_id' => $pedido->id,
+            'produto_id' => $produto->id,
+            'quantidade' => 2, // 2 x 15 = 30 (excede cota de 20)
+        ]);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert
+        $this->assertEquals(20, $resultado['cota']);
+        $this->assertEquals(30, $resultado['gasto']);
+        $this->assertEquals(-10, $resultado['saldo']);
+    }
+
+    /**
+     * Testa que apenas pedidos do mês atual são considerados no cálculo.
+     */
+    public function test_calcula_saldo_considera_apenas_mes_atual(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 888999,
+            'nome' => 'Juliana Souza',
+        ]);
+
+        CotaEspecial::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'valor' => 50,
+        ]);
+
+        $produto = Produto::factory()->create(['valor' => 10]);
+
+        // Pedido do mês passado (não deve ser contabilizado)
+        $pedidoMesPassado = new Pedido([
+            'consumidor_codpes' => $consumidor->codpes,
+            'estado' => 'REALIZADO',
+        ]);
+        $pedidoMesPassado->created_at = now()->subMonth();
+        $pedidoMesPassado->updated_at = now()->subMonth();
+        $pedidoMesPassado->save();
+
+        ItemPedido::create([
+            'pedido_id' => $pedidoMesPassado->id,
+            'produto_id' => $produto->id,
+            'quantidade' => 3, // 3 x 10 = 30 (mês passado)
+        ]);
+
+        // Pedido do mês atual
+        $pedidoMesAtual = Pedido::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'estado' => 'REALIZADO',
+        ]);
+
+        ItemPedido::create([
+            'pedido_id' => $pedidoMesAtual->id,
+            'produto_id' => $produto->id,
+            'quantidade' => 1, // 1 x 10 = 10 (mês atual)
+        ]);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert - Deve considerar apenas o pedido do mês atual
+        $this->assertEquals(50, $resultado['cota']);
+        $this->assertEquals(10, $resultado['gasto']);
+        $this->assertEquals(40, $resultado['saldo']);
+    }
+
+    /**
+     * Testa que cota especial tem prioridade sobre cota regular.
+     */
+    public function test_cota_especial_tem_prioridade_sobre_cota_regular(): void
+    {
+        // Arrange
+        $consumidor = Consumidor::factory()->create([
+            'codpes' => 666555,
+            'nome' => 'Ricardo Mendes',
+        ]);
+
+        // Cadastra cota especial
+        CotaEspecial::create([
+            'consumidor_codpes' => $consumidor->codpes,
+            'valor' => 100,
+        ]);
+
+        // Cadastra cota regular (que seria aplicável)
+        CotaRegular::create([
+            'vinculo' => 'DOCENTE',
+            'valor' => 40,
+        ]);
+
+        $this->fakeReplicado->setVinculos(666555, 8, ['DOCENTE']);
+
+        // Act
+        $resultado = $this->cotaService->calcularSaldoParaConsumidor($consumidor);
+
+        // Assert - Deve usar cota especial (100), não a regular (40)
+        $this->assertEquals(100, $resultado['cota']);
+        $this->assertEquals(0, $resultado['gasto']);
+        $this->assertEquals(100, $resultado['saldo']);
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements the `CotaService` to handle the core logic for calculating consumer quotas and balances. It includes functionality to determine monthly quotas based on special and regular quotas, and calculates monthly spending from orders.

## Changes Made
- Added `HasFactory` trait and `$table` property to `Consumidor`, `CotaEspecial`, `CotaRegular`, and `Produto` models for better factory integration and explicit table naming.
- Created `app/Services/CotaService.php` which encapsulates the `calcularSaldoParaConsumidor` method.
- Implemented logic within `CotaService` to prioritize special quotas, then determine the highest regular quota based on active IME vínculos obtained from `ReplicadoService`.
- Implemented logic to calculate the total monthly spending by summing up product values from all items in orders placed within the current month.
- Added comprehensive unit tests for `CotaService` in `tests/Unit/CotaServiceTest.php` to ensure the correctness of quota and balance calculations under various scenarios.

## Related Issues
Closes #15