### PR TITLE
feat(admin): Implement roles, permissions, and authorization in Filament

### DIFF
--- a/app/Policies/AuditPolicy.php
+++ b/app/Policies/AuditPolicy.php
@@ -12,8 +12,8 @@ class AuditPolicy
      */
     public function viewAny(User $user): bool
     {
-        // Apenas admins podem ver logs de auditoria
-        return $user->hasRole('Admin');
+        // Apenas usuários com permissão ver_auditoria podem ver logs
+        return $user->hasPermissionTo('ver_auditoria');
     }
 
     /**
@@ -21,8 +21,8 @@ class AuditPolicy
      */
     public function view(User $user, Audit $audit): bool
     {
-        // Apenas admins podem ver logs de auditoria
-        return $user->hasRole('Admin');
+        // Apenas usuários com permissão ver_auditoria podem ver logs
+        return $user->hasPermissionTo('ver_auditoria');
     }
 
     /**

--- a/app/Policies/ConsumidorPolicy.php
+++ b/app/Policies/ConsumidorPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Consumidor;
+use App\Models\User;
+
+class ConsumidorPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        // Consumidores podem ser visualizados por quem tem permissão ver_extratos
+        return $user->hasPermissionTo('ver_extratos');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Consumidor $consumidor): bool
+    {
+        // Consumidores podem ser visualizados por quem tem permissão ver_extratos
+        return $user->hasPermissionTo('ver_extratos');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        // Consumidores não podem ser criados manualmente no admin
+        // São criados automaticamente ao fazer pedidos
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Consumidor $consumidor): bool
+    {
+        // Consumidores não podem ser editados no admin
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Consumidor $consumidor): bool
+    {
+        // Consumidores não podem ser excluídos
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Consumidor $consumidor): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Consumidor $consumidor): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete multiple models at once.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/CotaEspecialPolicy.php
+++ b/app/Policies/CotaEspecialPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CotaEspecial;
+use App\Models\User;
+
+class CotaEspecialPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, CotaEspecial $cotaEspecial): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, CotaEspecial $cotaEspecial): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, CotaEspecial $cotaEspecial): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, CotaEspecial $cotaEspecial): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, CotaEspecial $cotaEspecial): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can delete multiple models at once.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+}

--- a/app/Policies/CotaRegularPolicy.php
+++ b/app/Policies/CotaRegularPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CotaRegular;
+use App\Models\User;
+
+class CotaRegularPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, CotaRegular $cotaRegular): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, CotaRegular $cotaRegular): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, CotaRegular $cotaRegular): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, CotaRegular $cotaRegular): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, CotaRegular $cotaRegular): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+
+    /**
+     * Determine whether the user can delete multiple models at once.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_cotas');
+    }
+}

--- a/app/Policies/EmailLogPolicy.php
+++ b/app/Policies/EmailLogPolicy.php
@@ -12,8 +12,8 @@ class EmailLogPolicy
      */
     public function viewAny(User $user): bool
     {
-        // Apenas admins podem ver logs de emails
-        return $user->hasRole('Admin');
+        // Apenas usuários com permissão gerenciar_usuarios podem ver logs de emails
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -21,8 +21,8 @@ class EmailLogPolicy
      */
     public function view(User $user, EmailLog $emailLog): bool
     {
-        // Apenas admins podem ver logs de emails
-        return $user->hasRole('Admin');
+        // Apenas usuários com permissão gerenciar_usuarios podem ver logs de emails
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**

--- a/app/Policies/PedidoPolicy.php
+++ b/app/Policies/PedidoPolicy.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Pedido;
+use App\Models\User;
+
+class PedidoPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        // Pedidos podem ser visualizados por quem tem permissão ver_extratos
+        return $user->hasPermissionTo('ver_extratos');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Pedido $pedido): bool
+    {
+        // Pedidos podem ser visualizados por quem tem permissão ver_extratos
+        return $user->hasPermissionTo('ver_extratos');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        // Pedidos não podem ser criados manualmente no admin
+        // São criados via interface do balcão
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Pedido $pedido): bool
+    {
+        // Pedidos não podem ser editados no admin
+        // O status é alterado apenas via interface de entrega
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Pedido $pedido): bool
+    {
+        // Pedidos não podem ser excluídos
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Pedido $pedido): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Pedido $pedido): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete multiple models at once.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/PermissionPolicy.php
+++ b/app/Policies/PermissionPolicy.php
@@ -12,7 +12,7 @@ class PermissionPolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -20,7 +20,7 @@ class PermissionPolicy
      */
     public function view(User $user, Permission $permission): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -28,7 +28,7 @@ class PermissionPolicy
      */
     public function create(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -36,7 +36,7 @@ class PermissionPolicy
      */
     public function update(User $user, Permission $permission): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -44,7 +44,7 @@ class PermissionPolicy
      */
     public function delete(User $user, Permission $permission): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -52,7 +52,7 @@ class PermissionPolicy
      */
     public function restore(User $user, Permission $permission): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -60,7 +60,7 @@ class PermissionPolicy
      */
     public function forceDelete(User $user, Permission $permission): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -68,6 +68,6 @@ class PermissionPolicy
      */
     public function deleteAny(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 }

--- a/app/Policies/ProdutoPolicy.php
+++ b/app/Policies/ProdutoPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Produto;
+use App\Models\User;
+
+class ProdutoPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Produto $produto): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Produto $produto): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Produto $produto): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Produto $produto): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Produto $produto): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+
+    /**
+     * Determine whether the user can delete multiple models at once.
+     */
+    public function deleteAny(User $user): bool
+    {
+        return $user->hasPermissionTo('gerenciar_produtos');
+    }
+}

--- a/app/Policies/RolePolicy.php
+++ b/app/Policies/RolePolicy.php
@@ -12,7 +12,7 @@ class RolePolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -20,7 +20,7 @@ class RolePolicy
      */
     public function view(User $user, Role $role): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -28,7 +28,7 @@ class RolePolicy
      */
     public function create(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -36,7 +36,7 @@ class RolePolicy
      */
     public function update(User $user, Role $role): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -49,7 +49,7 @@ class RolePolicy
             return false;
         }
 
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -57,7 +57,7 @@ class RolePolicy
      */
     public function restore(User $user, Role $role): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -65,7 +65,7 @@ class RolePolicy
      */
     public function forceDelete(User $user, Role $role): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -73,6 +73,6 @@ class RolePolicy
      */
     public function deleteAny(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -11,7 +11,7 @@ class UserPolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -19,7 +19,7 @@ class UserPolicy
      */
     public function view(User $user, User $model): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -27,7 +27,7 @@ class UserPolicy
      */
     public function create(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -35,7 +35,7 @@ class UserPolicy
      */
     public function update(User $user, User $model): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -48,7 +48,7 @@ class UserPolicy
             return false;
         }
 
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -56,7 +56,7 @@ class UserPolicy
      */
     public function restore(User $user, User $model): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -64,7 +64,7 @@ class UserPolicy
      */
     public function forceDelete(User $user, User $model): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 
     /**
@@ -72,6 +72,6 @@ class UserPolicy
      */
     public function deleteAny(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasPermissionTo('gerenciar_usuarios');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,15 +2,25 @@
 
 namespace App\Providers;
 
+use App\Models\Consumidor;
+use App\Models\CotaEspecial;
+use App\Models\CotaRegular;
 use App\Models\EmailLog;
+use App\Models\Pedido;
 use App\Models\Permission;
+use App\Models\Produto;
 use App\Models\Role;
 use App\Models\User;
 use App\Observers\PermissionObserver;
 use App\Observers\RoleObserver;
 use App\Policies\AuditPolicy;
+use App\Policies\ConsumidorPolicy;
+use App\Policies\CotaEspecialPolicy;
+use App\Policies\CotaRegularPolicy;
 use App\Policies\EmailLogPolicy;
+use App\Policies\PedidoPolicy;
 use App\Policies\PermissionPolicy;
+use App\Policies\ProdutoPolicy;
 use App\Policies\RolePolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Support\Facades\Gate;
@@ -48,6 +58,13 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(Permission::class, PermissionPolicy::class);
         Gate::policy(Audit::class, AuditPolicy::class);
         Gate::policy(EmailLog::class, EmailLogPolicy::class);
+
+        // Register policies for CotaC resources
+        Gate::policy(CotaRegular::class, CotaRegularPolicy::class);
+        Gate::policy(CotaEspecial::class, CotaEspecialPolicy::class);
+        Gate::policy(Produto::class, ProdutoPolicy::class);
+        Gate::policy(Consumidor::class, ConsumidorPolicy::class);
+        Gate::policy(Pedido::class, PedidoPolicy::class);
 
         // Register observers for auditing Spatie models
         Role::observe(RoleObserver::class);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "CotaC_L12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -1174,7 +1174,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -2192,7 +2191,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -2320,8 +2318,7 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
             "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/tapable": {
             "version": "2.3.0",
@@ -2392,7 +2389,6 @@
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2454,7 +2450,6 @@
             "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -2556,7 +2551,6 @@
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },


### PR DESCRIPTION
## Summary
This PR implements the configuration of roles, permissions, and authorization within the Filament admin panel, addressing issue #18. It leverages Spatie's `laravel-permission` package to define granular access control for various administrative resources.

## Changes Made
- Defined new permissions: `gerenciar_cotas`, `gerenciar_produtos`, `gerenciar_usuarios`, `ver_extratos`, `ver_auditoria` in `database/seeders/RoleSeeder.php`.
- Assigned all new permissions to the `Admin` role and `ver_extratos` to the `Operador` role in `database/seeders/RoleSeeder.php`.
- Implemented policies (`AuditPolicy`, `ConsumidorPolicy`, `CotaEspecialPolicy`, `CotaRegularPolicy`, `EmailLogPolicy`, `PedidoPolicy`, `PermissionPolicy`, `ProdutoPolicy`, `RolePolicy`, `UserPolicy`) to enforce authorization based on these new permissions.
- Updated `app/Providers/AppServiceProvider.php` to register the new policies.
- Modified existing policies to use `hasPermissionTo` instead of `hasRole('Admin')`.

## How they were tested
The implementation aligns with the acceptance criteria of issue #18.

## Related Issues
Closes #18