### PR TITLE
feat(admin): Implement CRUD resources for CotaRegular, CotaEspecial, Produto, and User

### DIFF
--- a/app/Filament/Resources/CotaEspecialResource.php
+++ b/app/Filament/Resources/CotaEspecialResource.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\CotaEspecialResource\Pages;
+use App\Models\CotaEspecial;
+use BackedEnum;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class CotaEspecialResource extends Resource
+{
+    protected static ?string $model = CotaEspecial::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedStar;
+
+    protected static UnitEnum|string|null $navigationGroup = 'Gerenciamento';
+
+    protected static ?int $navigationSort = 11;
+
+    protected static ?string $navigationLabel = 'Cotas Especiais';
+
+    protected static ?string $modelLabel = 'Cota Especial';
+
+    protected static ?string $pluralModelLabel = 'Cotas Especiais';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('consumidor_codpes')
+                    ->label(__('Nº USP (codpes)'))
+                    ->required()
+                    ->numeric()
+                    ->unique(ignoreRecord: true)
+                    ->minLength(6)
+                    ->maxLength(8)
+                    ->helperText(__('Número USP do consumidor')),
+                TextInput::make('valor')
+                    ->label(__('Valor'))
+                    ->required()
+                    ->numeric()
+                    ->minValue(0)
+                    ->helperText(__('Valor da cota mensal especial em unidades'))
+                    ->suffix('unidades'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('consumidor_codpes')
+                    ->label(__('Nº USP'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('consumidor.nome')
+                    ->label(__('Nome'))
+                    ->searchable()
+                    ->sortable()
+                    ->default(__('Consumidor não cadastrado')),
+                TextColumn::make('valor')
+                    ->label(__('Valor'))
+                    ->numeric()
+                    ->sortable()
+                    ->suffix(' unidades'),
+                TextColumn::make('created_at')
+                    ->label(__('Criado em'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->label(__('Atualizado em'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('consumidor_codpes', 'asc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCotaEspeciais::route('/'),
+            'create' => Pages\CreateCotaEspecial::route('/create'),
+            'edit' => Pages\EditCotaEspecial::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/CotaEspecialResource/Pages/CreateCotaEspecial.php
+++ b/app/Filament/Resources/CotaEspecialResource/Pages/CreateCotaEspecial.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\CotaEspecialResource\Pages;
+
+use App\Filament\Resources\CotaEspecialResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCotaEspecial extends CreateRecord
+{
+    protected static string $resource = CotaEspecialResource::class;
+}

--- a/app/Filament/Resources/CotaEspecialResource/Pages/EditCotaEspecial.php
+++ b/app/Filament/Resources/CotaEspecialResource/Pages/EditCotaEspecial.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CotaEspecialResource\Pages;
+
+use App\Filament\Resources\CotaEspecialResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCotaEspecial extends EditRecord
+{
+    protected static string $resource = CotaEspecialResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CotaEspecialResource/Pages/ListCotaEspeciais.php
+++ b/app/Filament/Resources/CotaEspecialResource/Pages/ListCotaEspeciais.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Resources\CotaEspecialResource\Pages;
+
+use App\Filament\Resources\CotaEspecialResource;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCotaEspeciais extends ListRecords
+{
+    protected static string $resource = CotaEspecialResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToDashboard')
+                ->label('Voltar')
+                ->icon('heroicon-o-arrow-left')
+                ->url(url('/admin'))
+                ->color('gray'),
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CotaRegularResource.php
+++ b/app/Filament/Resources/CotaRegularResource.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\CotaRegularResource\Pages;
+use App\Models\CotaRegular;
+use BackedEnum;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class CotaRegularResource extends Resource
+{
+    protected static ?string $model = CotaRegular::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static UnitEnum|string|null $navigationGroup = 'Gerenciamento';
+
+    protected static ?int $navigationSort = 10;
+
+    protected static ?string $navigationLabel = 'Cotas Regulares';
+
+    protected static ?string $modelLabel = 'Cota Regular';
+
+    protected static ?string $pluralModelLabel = 'Cotas Regulares';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('vinculo')
+                    ->label(__('Vínculo'))
+                    ->required()
+                    ->maxLength(50)
+                    ->unique(ignoreRecord: true)
+                    ->helperText(__('Tipo de vínculo USP (ex: DOCENTE, SERVIDOR, ALUNOPOS)')),
+                TextInput::make('valor')
+                    ->label(__('Valor'))
+                    ->required()
+                    ->numeric()
+                    ->minValue(0)
+                    ->helperText(__('Valor da cota mensal em unidades'))
+                    ->suffix('unidades'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('vinculo')
+                    ->label(__('Vínculo'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('valor')
+                    ->label(__('Valor'))
+                    ->numeric()
+                    ->sortable()
+                    ->suffix(' unidades'),
+                TextColumn::make('created_at')
+                    ->label(__('Criado em'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->label(__('Atualizado em'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('vinculo', 'asc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCotaRegulares::route('/'),
+            'create' => Pages\CreateCotaRegular::route('/create'),
+            'edit' => Pages\EditCotaRegular::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/CotaRegularResource/Pages/CreateCotaRegular.php
+++ b/app/Filament/Resources/CotaRegularResource/Pages/CreateCotaRegular.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\CotaRegularResource\Pages;
+
+use App\Filament\Resources\CotaRegularResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCotaRegular extends CreateRecord
+{
+    protected static string $resource = CotaRegularResource::class;
+}

--- a/app/Filament/Resources/CotaRegularResource/Pages/EditCotaRegular.php
+++ b/app/Filament/Resources/CotaRegularResource/Pages/EditCotaRegular.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\CotaRegularResource\Pages;
+
+use App\Filament\Resources\CotaRegularResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCotaRegular extends EditRecord
+{
+    protected static string $resource = CotaRegularResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/CotaRegularResource/Pages/ListCotaRegulares.php
+++ b/app/Filament/Resources/CotaRegularResource/Pages/ListCotaRegulares.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Resources\CotaRegularResource\Pages;
+
+use App\Filament\Resources\CotaRegularResource;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCotaRegulares extends ListRecords
+{
+    protected static string $resource = CotaRegularResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToDashboard')
+                ->label('Voltar')
+                ->icon('heroicon-o-arrow-left')
+                ->url(url('/admin'))
+                ->color('gray'),
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProdutoResource.php
+++ b/app/Filament/Resources/ProdutoResource.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ProdutoResource\Pages;
+use App\Models\Produto;
+use BackedEnum;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class ProdutoResource extends Resource
+{
+    protected static ?string $model = Produto::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedShoppingBag;
+
+    protected static UnitEnum|string|null $navigationGroup = 'Gerenciamento';
+
+    protected static ?int $navigationSort = 12;
+
+    protected static ?string $navigationLabel = 'Produtos';
+
+    protected static ?string $modelLabel = 'Produto';
+
+    protected static ?string $pluralModelLabel = 'Produtos';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('nome')
+                    ->label(__('Nome'))
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->helperText(__('Nome do produto')),
+                TextInput::make('valor')
+                    ->label(__('Valor'))
+                    ->required()
+                    ->numeric()
+                    ->minValue(0)
+                    ->helperText(__('Valor do produto em unidades de cota'))
+                    ->suffix('unidades'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('nome')
+                    ->label(__('Nome'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('valor')
+                    ->label(__('Valor'))
+                    ->numeric()
+                    ->sortable()
+                    ->suffix(' unidades'),
+                TextColumn::make('created_at')
+                    ->label(__('Criado em'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->label(__('Atualizado em'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('nome', 'asc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListProdutos::route('/'),
+            'create' => Pages\CreateProduto::route('/create'),
+            'edit' => Pages\EditProduto::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProdutoResource/Pages/CreateProduto.php
+++ b/app/Filament/Resources/ProdutoResource/Pages/CreateProduto.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ProdutoResource\Pages;
+
+use App\Filament\Resources\ProdutoResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateProduto extends CreateRecord
+{
+    protected static string $resource = ProdutoResource::class;
+}

--- a/app/Filament/Resources/ProdutoResource/Pages/EditProduto.php
+++ b/app/Filament/Resources/ProdutoResource/Pages/EditProduto.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ProdutoResource\Pages;
+
+use App\Filament\Resources\ProdutoResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditProduto extends EditRecord
+{
+    protected static string $resource = ProdutoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProdutoResource/Pages/ListProdutos.php
+++ b/app/Filament/Resources/ProdutoResource/Pages/ListProdutos.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Resources\ProdutoResource\Pages;
+
+use App\Filament\Resources\ProdutoResource;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListProdutos extends ListRecords
+{
+    protected static string $resource = ProdutoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToDashboard')
+                ->label('Voltar')
+                ->icon('heroicon-o-arrow-left')
+                ->url(url('/admin'))
+                ->color('gray'),
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -36,10 +36,11 @@ class UserForm
                     ->required(fn (string $context): bool => $context === 'create')
                     ->maxLength(255),
                 Select::make('roles')
-                    ->relationship('roles', 'name')
+                    ->relationship('roles', 'name', fn ($query) => $query->whereIn('name', ['Admin', 'Operador']))
                     ->multiple()
                     ->preload()
-                    ->searchable(),
+                    ->searchable()
+                    ->helperText('Selecione os papéis do usuário (Admin ou Operador)'),
             ]);
     }
 }

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -51,4 +51,17 @@ class UserResource extends Resource
             'edit' => EditUser::route('/{record}/edit'),
         ];
     }
+
+    /**
+     * Customiza a query para exibir apenas usuários com roles Admin ou Operador.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<User>
+     */
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereHas('roles', function ($query) {
+                $query->whereIn('name', ['Admin', 'Operador']);
+            });
+    }
 }

--- a/app/Filament/Widgets/NavigationCardsWidget.php
+++ b/app/Filament/Widgets/NavigationCardsWidget.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Widgets;
 
 use App\Filament\Resources\AuditResource;
+use App\Filament\Resources\CotaEspecialResource;
+use App\Filament\Resources\CotaRegularResource;
 use App\Filament\Resources\EmailLogResource;
 use App\Filament\Resources\Permissions\PermissionResource;
+use App\Filament\Resources\ProdutoResource;
 use App\Filament\Resources\Roles\RoleResource;
 use App\Filament\Resources\Users\UserResource;
 use Filament\Widgets\Widget;
@@ -28,6 +31,30 @@ class NavigationCardsWidget extends Widget
                 'url' => UserResource::getUrl('index'),
                 'color' => 'primary',
                 'stats' => \App\Models\User::count(),
+            ],
+            [
+                'title' => 'Cotas Regulares',
+                'description' => 'Gerenciar cotas por vínculo USP',
+                'icon' => 'heroicon-o-clipboard-document-list',
+                'url' => CotaRegularResource::getUrl('index'),
+                'color' => 'blue',
+                'stats' => \App\Models\CotaRegular::count(),
+            ],
+            [
+                'title' => 'Cotas Especiais',
+                'description' => 'Gerenciar cotas individuais customizadas',
+                'icon' => 'heroicon-o-star',
+                'url' => CotaEspecialResource::getUrl('index'),
+                'color' => 'amber',
+                'stats' => \App\Models\CotaEspecial::count(),
+            ],
+            [
+                'title' => 'Produtos',
+                'description' => 'Gerenciar produtos disponíveis',
+                'icon' => 'heroicon-o-shopping-bag',
+                'url' => ProdutoResource::getUrl('index'),
+                'color' => 'green',
+                'stats' => \App\Models\Produto::count(),
             ],
             [
                 'title' => 'Perfis',

--- a/resources/views/filament/widgets/navigation-cards-widget.blade.php
+++ b/resources/views/filament/widgets/navigation-cards-widget.blade.php
@@ -34,8 +34,8 @@
                 {{-- Header --}}
                 <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px;">
                     {{-- Icon container --}}
-                    <div style="flex-shrink: 0; padding: 10px; border-radius: 8px; background-color: {{ $card['color'] === 'primary' ? 'rgba(16, 148, 171, 0.1)' : ($card['color'] === 'success' ? 'rgba(16, 185, 129, 0.1)' : ($card['color'] === 'warning' ? 'rgba(252, 180, 33, 0.1)' : ($card['color'] === 'gray' ? 'rgba(107, 114, 128, 0.1)' : 'rgba(59, 130, 246, 0.1)'))) }};">
-                        <svg style="width: 20px; height: 20px; color: {{ $card['color'] === 'primary' ? '#1094AB' : ($card['color'] === 'success' ? '#10b981' : ($card['color'] === 'warning' ? '#FCB421' : ($card['color'] === 'gray' ? '#6b7280' : '#3b82f6'))) }};"
+                    <div style="flex-shrink: 0; padding: 10px; border-radius: 8px; background-color: {{ $card['color'] === 'primary' ? 'rgba(16, 148, 171, 0.1)' : ($card['color'] === 'success' ? 'rgba(16, 185, 129, 0.1)' : ($card['color'] === 'warning' ? 'rgba(252, 180, 33, 0.1)' : ($card['color'] === 'gray' ? 'rgba(107, 114, 128, 0.1)' : ($card['color'] === 'info' ? 'rgba(59, 130, 246, 0.1)' : ($card['color'] === 'blue' ? 'rgba(59, 130, 246, 0.1)' : ($card['color'] === 'amber' ? 'rgba(245, 158, 11, 0.1)' : ($card['color'] === 'green' ? 'rgba(34, 197, 94, 0.1)' : 'rgba(59, 130, 246, 0.1)'))))))) }};">
+                        <svg style="width: 20px; height: 20px; color: {{ $card['color'] === 'primary' ? '#1094AB' : ($card['color'] === 'success' ? '#10b981' : ($card['color'] === 'warning' ? '#FCB421' : ($card['color'] === 'gray' ? '#6b7280' : ($card['color'] === 'info' ? '#3b82f6' : ($card['color'] === 'blue' ? '#3b82f6' : ($card['color'] === 'amber' ? '#f59e0b' : ($card['color'] === 'green' ? '#22c55e' : '#3b82f6'))))))) }};"
                              fill="none"
                              stroke="currentColor"
                              viewBox="0 0 24 24"
@@ -48,6 +48,12 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
                             @elseif($card['icon'] === 'heroicon-o-document-text')
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                            @elseif($card['icon'] === 'heroicon-o-clipboard-document-list')
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"/>
+                            @elseif($card['icon'] === 'heroicon-o-star')
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+                            @elseif($card['icon'] === 'heroicon-o-shopping-bag')
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"/>
                             @elseif($card['icon'] === 'heroicon-o-envelope')
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                             @endif
@@ -71,7 +77,7 @@
                 </p>
 
                 {{-- Footer --}}
-                <div style="display: flex; align-items: center; font-size: 13px; font-weight: 600; color: {{ $card['color'] === 'primary' ? '#1094AB' : ($card['color'] === 'success' ? '#10b981' : ($card['color'] === 'warning' ? '#FCB421' : ($card['color'] === 'gray' ? '#6b7280' : '#3b82f6'))) }};">
+                <div style="display: flex; align-items: center; font-size: 13px; font-weight: 600; color: {{ $card['color'] === 'primary' ? '#1094AB' : ($card['color'] === 'success' ? '#10b981' : ($card['color'] === 'warning' ? '#FCB421' : ($card['color'] === 'gray' ? '#6b7280' : ($card['color'] === 'info' ? '#3b82f6' : ($card['color'] === 'blue' ? '#3b82f6' : ($card['color'] === 'amber' ? '#f59e0b' : ($card['color'] === 'green' ? '#22c55e' : '#3b82f6'))))))) }};">
                     <span>Acessar</span>
                     <svg style="width: 14px; height: 14px; margin-left: 6px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/>


### PR DESCRIPTION
## Summary
This PR implements the CRUD interfaces for `Cotas Regulares`, `Cotas Especiais`, `Produtos`, and `Usuários` within the Filament admin panel, addressing issue #19.

## Changes Made
- Created `CotaRegularResource`, `CotaEspecialResource`, and `ProdutoResource` with their respective pages for managing these entities.
- Modified `UserResource` to manage only users with 'Admin' and 'Operador' roles and updated the `UserForm` schema to restrict role selection.
- Added navigation cards for the new resources in `NavigationCardsWidget.php` and `navigation-cards-widget.blade.php`.

## How they were tested
The implementation aligns with the acceptance criteria of issue #19. Manual testing was performed to verify CRUD operations for each resource and role-based access control for users.

## Related Issues
Closes #19