### PR TITLE
fix(cota): use env for unit code and normalize vinculos

### DIFF
--- a/config/replicado.php
+++ b/config/replicado.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'codundclg' => env('REPLICADO_CODUNDCLG', 45),
+];


### PR DESCRIPTION
# Fix Cota Regular Bug (#44)

## Description

This PR resolves issue #44 where "Cota Regular" was not being automatically applied to servers with active vinculos.

The investigation revealed two root causes:
1. **Unit Code Mismatch:** The `CotaService` was hardcoded to use unit code `8` (IME), but the Replicado environment for some users returned unit code `45` (also IME).
2. **Case Sensitivity:** Vinculos returned by Replicado (e.g., "servidor") did not match the uppercase format stored in the `cota_regulares` table (e.g., "SERVIDOR").

## Changes

- **Configuration:** Created `config/replicado.php` to expose `REPLICADO_CODUNDCLG` from environment variables, allowing dynamic configuration of the unit code.
- **Service Logic:** Updated `CotaService.php` to:
    - Use the configured unit code (`config('replicado.codundclg')`) instead of a hardcoded constant.
    - Normalize all vinculos received from Replicado to uppercase to ensure case-insensitive matching.
    - Added debug logging to trace quota calculation.
- **Tests:** Updated `CotaServiceTest.php` to:
    - Mock the configuration value.
    - Add a regression test `test_calcula_saldo_com_vinculo_case_insensitive` to verify the fix.

## Verification

- **Automated Tests:** All tests passed (`./vendor/bin/sail artisan test`).
- **Manual Verification:** Verified via `tinker` that users with `codundclg=45` (e.g., `7762448`) now correctly receive their quota.

## Checklist

- [x] Code follows the project's coding standards.
- [x] Tests have been added/updated to cover the changes.
- [x] All tests passed locally.
